### PR TITLE
use default travis cpp env for faster build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,7 @@ language: cpp
 compiler:
   - gcc
   - clang
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.8
-    packages:
-    - g++-6
-    - clang-3.8
-install:
-- "[ $CXX = g++ ] && export CXX=g++-6 || true"
-- "[ $CXX = clang++ ] && export CXX=clang++-3.8 || true"
+env:
+  - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
 script:
   - bash build.sh


### PR DESCRIPTION
* Use Default Travis Cpp ENV as we don't need anything else as of now.
* Leads to faster builds.