### PR TITLE
Reachable and unmet dep nodes

### DIFF
--- a/include/Manager.h
+++ b/include/Manager.h
@@ -56,6 +56,8 @@ struct Manager {
 	// execution
 	std::set<int> reachable_nodes;
 
+	std::set<int> unmet_deps;
+
 	// Mutex to make sure the update of to_run 
 	// and completed_nodes are `atomic`
 	std::mutex update_lock;
@@ -76,6 +78,8 @@ struct Manager {
 	// Method to explore all reachable nodes from
 	// the mentioned `src` node
 	void explore_reachable_nodes(int src);
+
+	void check_dependencies();
 
 	void execute(int src_node = 0);
 

--- a/include/Manager.h
+++ b/include/Manager.h
@@ -52,6 +52,10 @@ struct Manager {
 	// To keep track of completion order.
 	std::vector<int> completed_vec;
 
+	// Reachable nodes from current src of
+	// execution
+	std::set<int> reachable_nodes;
+
 	// Mutex to make sure the update of to_run 
 	// and completed_nodes are `atomic`
 	std::mutex update_lock;
@@ -68,6 +72,10 @@ struct Manager {
 	// Returns bool representing if all parents
 	// of current indexed node have finished
 	bool if_all_parents_fin(int i);
+
+	// Method to explore all reachable nodes from
+	// the mentioned `src` node
+	void explore_reachable_nodes(int src);
 
 	void execute(int src_node = 0);
 

--- a/include/Manager.h
+++ b/include/Manager.h
@@ -79,6 +79,8 @@ struct Manager {
 
 	void execute(int src_node = 0);
 
+	void clear_state();
+
 	// Returns the order in which nodes
 	// executed.
 	// Note : Returns empty vector if

--- a/lib/Manager.cpp
+++ b/lib/Manager.cpp
@@ -42,15 +42,25 @@ void Manager::explore_reachable_nodes(int src){
 	}
 }
 
+void Manager::clear_state(){
+	this->reachable_nodes = {};
+	this->completed = {};
+}
+
 void Manager::execute(int src_node_idx){
 	// Get the src node ready to run.
 	to_run.push(src_node_idx);
+
+	// reset completion order for this execution
+	this->completed_vec = {};
+
+	this->explore_reachable_nodes(src_node_idx);
 
 	// 1 Thread per Node Mode
 	std::vector<std::thread> threads;
 	
 	// Run till all nodes are completed.
-	while(completed.size() < nodes.size()){
+	while(completed.size() < reachable_nodes.size()){
 		{
 			std::lock_guard<std::mutex> Lock(update_lock);
 
@@ -76,4 +86,7 @@ void Manager::execute(int src_node_idx){
 	for(auto& thread : threads){
 		thread.join();
 	}
+
+	// for next execution
+	Manager::clear_state();
 }

--- a/lib/Manager.cpp
+++ b/lib/Manager.cpp
@@ -33,6 +33,15 @@ void Manager::update(std::set<int> children,int id){
 	} // Scope of Lock ends (i.e. Mutex is up for grabs)
 }
 
+void Manager::explore_reachable_nodes(int src){
+	this->reachable_nodes.insert(src);
+	auto& node = *(this->nodes[src]);
+	// explore children
+	for(auto& child: node.children){
+		Manager::explore_reachable_nodes(child);
+	}
+}
+
 void Manager::execute(int src_node_idx){
 	// Get the src node ready to run.
 	to_run.push(src_node_idx);

--- a/test/test.cpu.cpp
+++ b/test/test.cpu.cpp
@@ -68,30 +68,29 @@ TEST_CASE( "Graph execution order is correct.", "[manager]" ) {
 }
 
 TEST_CASE( "Reachable nodes.", "[manager]" ) {
-	auto fun0 = []() {};
-	auto fun1 = []() { std::this_thread::sleep_for(std::chrono::microseconds(5000)); };
+	auto func = []() {};
 
 	Manager m;
 
-	auto& node0 = m.append_node(0, fun0);
-	auto& node1 = m.append_node(1, fun1);
-	auto& node2 = m.append_node(2, fun0);
-	auto& node3 = m.append_node(3, fun0);
+	auto& node0 = m.append_node(0, func);
+	auto& node1 = m.append_node(1, func);
+	auto& node2 = m.append_node(2, func);
+	auto& node3 = m.append_node(3, func);
 
 	node0 >> (node1, node2);
 	m.explore_reachable_nodes(0);
 	std::set<int> expected_nodes_from_0 = {0, 1, 2};
 	REQUIRE(m.reachable_nodes == expected_nodes_from_0);
-	m.reachable_nodes = {};
+	m.clear_state();
 
 	m.explore_reachable_nodes(1);
 	std::set<int> expected_nodes_from_1 = {1};
 	REQUIRE(m.reachable_nodes == expected_nodes_from_1);
-	m.reachable_nodes = {};
+	m.clear_state();
 
 	node2 >> node3;
 	m.explore_reachable_nodes(2);
 	std::set<int> expected_nodes_from_2 = {2, 3};
 	REQUIRE(m.reachable_nodes == expected_nodes_from_2);
-	m.reachable_nodes = {};	
+	m.clear_state();	
 }

--- a/test/test.cpu.cpp
+++ b/test/test.cpu.cpp
@@ -54,11 +54,17 @@ TEST_CASE( "Graph execution order is correct.", "[manager]" ) {
 	auto& node2 = m.append_node(2, fun0);
 	auto& node3 = m.append_node(3, fun0);
 
-	node0 >> (node1, node2) >> node3;
-	m.execute();
+	node0 >> (node1, node2);
+	m.execute(0);
 
-	std::vector<int> expected_order = {0, 2, 1, 3};
-	REQUIRE(m.execution_order() == expected_order);
+	std::vector<int> expected_order_0 = {0, 2, 1};
+	REQUIRE(m.execution_order() == expected_order_0);
+	
+	(node1, node2) >> node3;
+	m.execute(0);
+	
+	std::vector<int> expected_order_1 = {0, 2, 1, 3};
+	REQUIRE(m.execution_order() == expected_order_1);
 }
 
 TEST_CASE( "Reachable nodes.", "[manager]" ) {

--- a/test/test.cpu.cpp
+++ b/test/test.cpu.cpp
@@ -60,3 +60,32 @@ TEST_CASE( "Graph execution order is correct.", "[manager]" ) {
 	std::vector<int> expected_order = {0, 2, 1, 3};
 	REQUIRE(m.execution_order() == expected_order);
 }
+
+TEST_CASE( "Reachable nodes.", "[manager]" ) {
+	auto fun0 = []() {};
+	auto fun1 = []() { std::this_thread::sleep_for(std::chrono::microseconds(5000)); };
+
+	Manager m;
+
+	auto& node0 = m.append_node(0, fun0);
+	auto& node1 = m.append_node(1, fun1);
+	auto& node2 = m.append_node(2, fun0);
+	auto& node3 = m.append_node(3, fun0);
+
+	node0 >> (node1, node2);
+	m.explore_reachable_nodes(0);
+	std::set<int> expected_nodes_from_0 = {0, 1, 2};
+	REQUIRE(m.reachable_nodes == expected_nodes_from_0);
+	m.reachable_nodes = {};
+
+	m.explore_reachable_nodes(1);
+	std::set<int> expected_nodes_from_1 = {1};
+	REQUIRE(m.reachable_nodes == expected_nodes_from_1);
+	m.reachable_nodes = {};
+
+	node2 >> node3;
+	m.explore_reachable_nodes(2);
+	std::set<int> expected_nodes_from_2 = {2, 3};
+	REQUIRE(m.reachable_nodes == expected_nodes_from_2);
+	m.reachable_nodes = {};	
+}

--- a/test/test.cpu.cpp
+++ b/test/test.cpu.cpp
@@ -42,7 +42,6 @@ TEST_CASE( "Node DSL constructs graph correctly.", "[node-dsl]" ) {
 	REQUIRE(node3.children == expected_node3_children);
 }
 
-
 TEST_CASE( "Graph execution order is correct.", "[manager]" ) {
 	auto fun0 = []() {};
 	auto fun1 = []() { std::this_thread::sleep_for(std::chrono::microseconds(5000)); };
@@ -93,4 +92,22 @@ TEST_CASE( "Reachable nodes.", "[manager]" ) {
 	std::set<int> expected_nodes_from_2 = {2, 3};
 	REQUIRE(m.reachable_nodes == expected_nodes_from_2);
 	m.clear_state();	
+}
+
+TEST_CASE( "Unmet Dependencies.", "[manager]" ) {
+	auto func = []() {};
+
+	Manager m;
+
+	auto& node0 = m.append_node(0, func);
+	auto& node1 = m.append_node(1, func);
+	auto& node2 = m.append_node(2, func);
+	auto& node3 = m.append_node(3, func);
+
+	node0 >> (node1, node2) >> node3;
+	
+	REQUIRE_NOTHROW(m.execute(0));
+	REQUIRE_THROWS(m.execute(1));
+	REQUIRE_THROWS(m.execute(2));
+	REQUIRE_THROWS(m.execute(3));
 }


### PR DESCRIPTION
Add support to check for ->
*  all reachable nodes from given source node and only run the reachable nodes.
*  all nodes with unmet dependencies and throw error with mentioning those nodes.