### PR TITLE
Multiple graphs

### DIFF
--- a/include/gsched/Manager.hpp
+++ b/include/gsched/Manager.hpp
@@ -52,7 +52,7 @@ struct Manager {
 	}
 
 	// Method which `atomically` updates the to_run and completed
-	void update(std::set<int> children,int id);
+	void enqueue_children(std::set<int> children,int id);
 
 	// Returns bool representing if all parents
 	// of current indexed node have finished
@@ -69,9 +69,13 @@ struct Manager {
 	// Start executing runnable threads
 	void schedule();
 
+	// Updates to_run with all nodes
+	// with zero parents.
+	void enqueue_root();
+
 	// Execute all reachable threads from
 	// `src_node`.
-	void execute(int src_node = 0, int max_thread = std::thread::hardware_concurrency());
+	void execute(int max_thread = std::thread::hardware_concurrency());
 	
 	// Reset all state variables for a
 	// new execution.

--- a/test/test.cpu.cpp
+++ b/test/test.cpu.cpp
@@ -9,7 +9,7 @@
 
 using namespace gsched;
 
-TEST_CASE( "Node DSL constructs graph correctly.", "[node-dsl]" ) {
+TEST_CASE( "Node DSL constructs graph correctly.", "[node]" ) {
 
 	auto dummy_func = [](){};
 
@@ -24,34 +24,27 @@ TEST_CASE( "Node DSL constructs graph correctly.", "[node-dsl]" ) {
 	// Use the Node DSL to construct a graph.
 	node0 >> (node1, node2) >> (node3, node4, node5);
 
-	// Expected parent/child relationship of the nodes.
-	std::set<int> expected_node0_parents {};
-	std::set<int> expected_node0_children {1, 2};
-	std::set<int> expected_node1_parents {0};
-	std::set<int> expected_node1_children {3, 4, 5};
-	std::set<int> expected_node2_parents {0};
-	std::set<int> expected_node2_children {3, 4, 5};
-	std::set<int> expected_node3_parents {1, 2};
-	std::set<int> expected_node3_children {};
-	std::set<int> expected_node4_parents {1, 2};
-	std::set<int> expected_node4_children {};
-	std::set<int> expected_node5_parents {1, 2};
-	std::set<int> expected_node5_children {};
+	auto set = [](std::set<int> expected){
+		return expected;
+	};
 
-	REQUIRE(node0.parents == expected_node0_parents);
-	REQUIRE(node1.parents == expected_node1_parents);
-	REQUIRE(node2.parents == expected_node2_parents);
-	REQUIRE(node3.parents == expected_node3_parents);
-	REQUIRE(node4.parents == expected_node4_parents);
-	REQUIRE(node5.parents == expected_node5_parents);
+	SECTION("Parents"){
+		REQUIRE(node0.parents == set({}) );
+		REQUIRE(node1.parents == set({0}) );
+		REQUIRE(node2.parents == set({0}) );
+		REQUIRE(node3.parents == set({1, 2}) );
+		REQUIRE(node4.parents == set({1, 2}) );
+		REQUIRE(node5.parents == set({1, 2}) );
+	}
 
-	REQUIRE(node0.children == expected_node0_children);
-	REQUIRE(node1.children == expected_node1_children);
-	REQUIRE(node2.children == expected_node2_children);
-	REQUIRE(node3.children == expected_node3_children);
-	REQUIRE(node4.children == expected_node4_children);
-	REQUIRE(node5.children == expected_node5_children);
-	
+	SECTION("Children"){
+		REQUIRE(node0.children == set({1, 2}) );
+		REQUIRE(node1.children == set({3, 4, 5}) );
+		REQUIRE(node2.children == set({3, 4, 5}) );
+		REQUIRE(node3.children == set({}) );
+		REQUIRE(node4.children == set({}) );
+		REQUIRE(node5.children == set({}) );
+	}
 }
 
 TEST_CASE( "Graph execution order is correct.", "[manager]" ) {
@@ -63,27 +56,24 @@ TEST_CASE( "Graph execution order is correct.", "[manager]" ) {
 	auto& node0 = m.append_node(0, fun0);
 	auto& node1 = m.append_node(1, fun1);
 	auto& node2 = m.append_node(2, fun0);
-	
-	node0 >> (node1, node2);
-	m.execute();
 
-	std::vector<int> expected_order_0 = {0, 2, 1};
-	if (std::thread::hardware_concurrency() == 1){
-		expected_order_0 = {0, 1, 2};
-	}
-
-	REQUIRE(m.execution_order() == expected_order_0);
+	auto assert_order = [&](std::vector<int> expected_order){
+		m.execute(2);
+		REQUIRE(m.execution_order() == expected_order);
+	};
 	
-	auto& node3 = m.append_node(3, fun0);
-	(node1, node2) >> node3;
-	m.execute();
-	
-	std::vector<int> expected_order_1 = {0, 2, 1, 3};
-	if (std::thread::hardware_concurrency() == 1){
-		expected_order_1 = {0, 1, 2, 3};
+	SECTION("First Graph"){
+		node0 >> (node1, node2);
+		assert_order({0, 2, 1});
 	}
 	
-	REQUIRE(m.execution_order() == expected_order_1);
+	SECTION("Second Graph"){
+		// define node3 before FIRST GRAPH
+		// will lead to multi-graph
+		auto& node3 = m.append_node(3, fun0);
+		node0 >> (node1, node2) >> node3;
+		assert_order({0, 2, 1, 3});
+	}
 }
 
 TEST_CASE( "Reachable nodes.", "[manager]" ) {
@@ -97,21 +87,25 @@ TEST_CASE( "Reachable nodes.", "[manager]" ) {
 	auto& node3 = m.append_node(3, func);
 
 	node0 >> (node1, node2);
-	m.explore_reachable_nodes(0);
-	std::set<int> expected_nodes_from_0 = {0, 1, 2};
-	REQUIRE(m.reachable_nodes == expected_nodes_from_0);
-	m.clear_state();
 
-	m.explore_reachable_nodes(1);
-	std::set<int> expected_nodes_from_1 = {1};
-	REQUIRE(m.reachable_nodes == expected_nodes_from_1);
-	m.clear_state();
+	auto explore_func = [&](int src_node, const std::set<int>& expected_nodes){
+		m.explore_reachable_nodes(src_node);
+		REQUIRE(m.reachable_nodes == expected_nodes);
+		m.clear_state();
+	};
 
-	node2 >> node3;
-	m.explore_reachable_nodes(2);
-	std::set<int> expected_nodes_from_2 = {2, 3};
-	REQUIRE(m.reachable_nodes == expected_nodes_from_2);
-	m.clear_state();	
+	SECTION("Node 0"){
+		explore_func(0, {0, 1, 2});
+	}
+	
+	SECTION("Node 1"){
+		explore_func(1, {1});
+	}
+	
+	SECTION("Node 2"){
+		node2 >> node3;
+		explore_func(2, {2, 3});
+	}
 }
 
 TEST_CASE( "Unmet Dependencies.", "[manager]" ) {
@@ -132,10 +126,13 @@ TEST_CASE( "Unmet Dependencies.", "[manager]" ) {
 		m.check_dependencies();
 	};
 
-	REQUIRE_NOTHROW(check_deps(0));
-	REQUIRE_THROWS(check_deps(1));
-	REQUIRE_THROWS(check_deps(2));
-	REQUIRE_THROWS(check_deps(3));
+	SECTION("No-Throw"){ REQUIRE_NOTHROW(check_deps(0)); }
+	
+	SECTION("Throws"){
+		REQUIRE_THROWS(check_deps(1));
+		REQUIRE_THROWS(check_deps(2));
+		REQUIRE_THROWS(check_deps(3));
+	}
 }
 
 TEST_CASE( "Max Thread.", "[manager]" ) {
@@ -150,18 +147,19 @@ TEST_CASE( "Max Thread.", "[manager]" ) {
 	auto& node3 = m.append_node(3, fun0);
 
 	node0 >> (node1, node2) >> node3;
-	m.execute(1);
 
-	std::vector<int> expected_order = {0, 1, 2, 3};
-	REQUIRE(m.execution_order() == expected_order);
-
-	m.execute();
-	std::vector<int> expected_order_mul_thread = {0, 2, 1, 3};
-	if (std::thread::hardware_concurrency() == 1){
-		expected_order_mul_thread = {0, 1, 2, 3};
-	}
+	auto assert_order = [&](int threads, std::vector<int> expected_order){
+		m.execute(threads);
+		REQUIRE(m.execution_order() == expected_order);
+	};
 	
-	REQUIRE(m.execution_order() == expected_order_mul_thread);
+	SECTION("Single Thread"){
+		assert_order(1, {0, 1, 2, 3});
+	}
+
+	SECTION("Multi-thread"){
+		assert_order(2, {0, 2, 1, 3});
+	}
 }
 
 TEST_CASE( "Multiple Graphs", "[manager]") {
@@ -182,6 +180,7 @@ TEST_CASE( "Multiple Graphs", "[manager]") {
 	auto& node9 = m.append_node(9, fun1);
 	auto& node10 = m.append_node(10, fun0);
 
+	// Define multiple graphs
 	node0 >> (node1, node2);
 
 	node3 >> node4;
@@ -193,45 +192,38 @@ TEST_CASE( "Multiple Graphs", "[manager]") {
 
 	std::set<int> cmpl_nodes = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
-	SECTION("Default Threads") {
-		m.execute();
+	auto assert_func = [&](int threads){
+		m.execute(threads);
 		auto exec_order = m.execution_order();
 		std::set<int> executed_nodes(exec_order.begin(), exec_order.end());
 		REQUIRE(cmpl_nodes == executed_nodes);
+	};
+
+	// Each section checks if all the nodes
+	// were executed or not.
+	SECTION("Default Threads"){
+		int threads = std::thread::hardware_concurrency();
+		assert_func(threads);
 	}
 
+	
 	SECTION("1 Thread"){
-		m.execute(1);
-		auto exec_order = m.execution_order();
-		std::set<int> executed_nodes(exec_order.begin(), exec_order.end());
-		REQUIRE(cmpl_nodes == executed_nodes);
+		assert_func(1);
 	}
 
 	SECTION("2 Thread"){
-		m.execute(2);
-		auto exec_order = m.execution_order();
-		std::set<int> executed_nodes(exec_order.begin(), exec_order.end());
-		REQUIRE(cmpl_nodes == executed_nodes);
+		assert_func(2);
 	}
 	
 	SECTION("3 Thread"){
-		m.execute(3);
-		auto exec_order = m.execution_order();
-		std::set<int> executed_nodes(exec_order.begin(), exec_order.end());
-		REQUIRE(cmpl_nodes == executed_nodes);
+		assert_func(3);
 	}
 
 	SECTION("4 Thread"){
-		m.execute(4);
-		auto exec_order = m.execution_order();
-		std::set<int> executed_nodes(exec_order.begin(), exec_order.end());
-		REQUIRE(cmpl_nodes == executed_nodes);
+		assert_func(4);
 	}
 	
 	SECTION("5 Thread"){
-		m.execute(5);
-		auto exec_order = m.execution_order();
-		std::set<int> executed_nodes(exec_order.begin(), exec_order.end());
-		REQUIRE(cmpl_nodes == executed_nodes);
+		assert_func(5);
 	}
 }

--- a/test/test.gpu.cu
+++ b/test/test.gpu.cu
@@ -53,7 +53,7 @@ TEST_CASE( "CUDA Graph execution order is correct.", "[CUDA-manager]" ) {
 	auto& node4 = m.append_node(4, cuda_func);
 
 	node0 >> (node1, node2) >> node3 >> node4;
-	m.execute(0);
+	m.execute();
 
 	std::vector<int> expected_order = {0, 2, 1, 3, 4};
 	if (std::thread::hardware_concurrency() == 1){

--- a/test/test.gpu.cu
+++ b/test/test.gpu.cu
@@ -5,10 +5,8 @@
 #include <thrust/device_vector.h>
 #include <thrust/transform.h>
 #include <thrust/sequence.h>
-#include <thrust/copy.h>
 #include <thrust/fill.h>
 #include <thrust/replace.h>
-#include <thrust/functional.h>
 
 #define CATCH_CONFIG_MAIN
 #include <catch/catch.hpp>
@@ -53,11 +51,8 @@ TEST_CASE( "CUDA Graph execution order is correct.", "[CUDA-manager]" ) {
 	auto& node4 = m.append_node(4, cuda_func);
 
 	node0 >> (node1, node2) >> node3 >> node4;
-	m.execute();
+	m.execute(2);
 
 	std::vector<int> expected_order = {0, 2, 1, 3, 4};
-	if (std::thread::hardware_concurrency() == 1){
-		expected_order = {0, 1, 2, 3, 4};
-	}
 	REQUIRE(m.execution_order() == expected_order);
 }


### PR DESCRIPTION
Changes
* Change the `execute` API to implicitly run the nodes with zero parents. 
* The above change adds the ability to schedule multiple-graphs simultaneously.
* Tests for execution of multiple-graph.
* Refactor the tests.